### PR TITLE
fix:'Function components is not a function expression'エラーを解消

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,5 +19,11 @@ module.exports = {
     'react',
   ],
   rules: {
+    "react/function-component-definition": [
+      2,
+      {
+        namedComponents: "function-declaration",
+      },
+    ],
   },
 };


### PR DESCRIPTION
close #2 

# なおったよ
`yarn start`
->
```
Compiled successfully!

You can now view react-template in the browser.

  Local:            http://localhost:3000
  On Your Network:  http://192.168.11.211:3000

Note that the development build is not optimized.
To create a production build, use yarn build.

assets by path static/ 1.52 MiB
  asset static/js/bundle.js 1.51 MiB [emitted] (name: main) 1 related asset
  asset static/js/node_modules_web-vitals_dist_web-vitals_js.chunk.js 6.89 KiB [emitted] 1 related asset
  asset static/media/logo.6ce24c58023cc2f8fd88fe9d219db6c6.svg 2.57 KiB [emitted] (auxiliary name: main)
asset index.html 1.67 KiB [emitted]
asset asset-manifest.json 546 bytes [emitted]
runtime modules 31.5 KiB 16 modules
modules by path ./node_modules/ 1.38 MiB 98 modules
modules by path ./src/ 18.1 KiB
  modules by path ./src/*.css 8.82 KiB
    ./src/index.css 2.72 KiB [built] [code generated]
    ./node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[1].oneOf[5].use[1]!./node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[1].oneOf[5].use[2]!./node_modules/source-map-loader/dist/cjs.js!./src/index.css 1.37 KiB [built] [code generated]
    ./src/App.css 2.72 KiB [built] [code generated]
    ./node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[1].oneOf[5].use[1]!./node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[1].oneOf[5].use[2]!./node_modules/source-map-loader/dist/cjs.js!./src/App.css 2 KiB [built] [code generated]
  modules by path ./src/*.jsx 4.3 KiB
    ./src/index.jsx 1.78 KiB [built] [code generated]
    ./src/App.jsx 2.52 KiB [built] [code generated]
  ./src/reportWebVitals.js 1.38 KiB [built] [code generated]
  ./src/logo.svg 3.61 KiB [built] [code generated]
webpack 5.65.0 compiled successfully in 2732 ms
No issues found
```